### PR TITLE
PHPコンテナにmysqliインストールを追加

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
         libjpeg62-turbo-dev \
         libpng-dev \
 #    && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install pdo_mysql
+    && docker-php-ext-install pdo_mysql mysqli
 
 # set recommended PHP.ini settings
 COPY conf.d/* /usr/local/etc/php/conf.d/


### PR DESCRIPTION
## 概要
phpコンテナにmysqliを追加しました。

## 内容
DB接続した場合に、`Call to undefined function mysqli_init() ` というエラーが画面に表示されたので
mysqliに対応するためmysqliのインストールを追加しました。

### 参考
[mysqliを使ってMySQL/MariaDBのデータベースへ接続](https://gray-code.com/php/connection-db-by-using-mysqli/#:~:text=%E4%BB%A5%E5%89%8D%E3%81%AF%E3%80%8Cmysql_query%E3%80%8D%E3%81%AA%E3%81%A9%E3%81%AEMySQL%E7%B3%BB%EF%BC%88i%E3%81%8C%E3%81%A4%E3%81%8B%E3%81%AA%E3%81%84%EF%BC%89%E3%81%AE%E9%96%A2%E6%95%B0%E3%81%8C%E4%BD%BF%E3%82%8F%E3%82%8C%E3%81%A6%E3%81%84%E3%81%BE%E3%81%97%E3%81%9F%E3%81%8C%E3%80%81PHP5.5%E4%BB%A5%E9%99%8D%E3%81%A7%E3%81%AF%E9%9D%9E%E6%8E%A8%E5%A5%A8%E3%81%A8%E3%81%AA%E3%82%8A%E3%81%BE%E3%81%97%E3%81%9F%E3%80%82%0A%E3%81%9D%E3%81%AE%E4%BB%A3%E6%9B%BF%E3%81%88%E3%81%A8%E3%81%AA%E3%81%A3%E3%81%9F%E3%81%AE%E3%81%8CMySQLi%E3%81%A7%E3%81%99%E3%80%82)

> 以前は「mysql_query」などのMySQL系（iがつかない）の関数が使われていましたが、PHP5.5以降では非推奨となりました。
その代替えとなったのがMySQLiです。

## 確認
CodeIgniterの公式チュートリアル：ニュースアプリにて動作確認

* [x] コンテナが全て正常に起動すること
* [x] コンテナ再作成後に、ニュースアプリで記事作成ができること